### PR TITLE
Update text to reflect that there is now a configuration file

### DIFF
--- a/configuration.rst
+++ b/configuration.rst
@@ -1,7 +1,7 @@
 Configuration
 =============
 
-Miniflux doesn't use any config file, **only environment variables**.
+Miniflux configuration is achieved by setting key/value pairs in the file `/etc/miniflux.conf`.  These are then made available to the application as environment variables.
 
 - :code:`DEBUG`: Toggle debug output (default is off)
 - :code:`WORKER_POOL_SIZE`: Number of background processes (default=5)


### PR DESCRIPTION
It appears the original text is outdated as adding environment variables to the shell has no effect, but adding key/value pairs to the /etc/miniflux.conf file does make them available to the application process.