### PR TITLE
Document Go 1.10 requirement

### DIFF
--- a/development.rst
+++ b/development.rst
@@ -5,7 +5,7 @@ Requirements
 ------------
 
 - Git
-- Go >= 1.9
+- Go >= 1.10
 - Godep :code:`go get -u github.com/golang/dep/cmd/dep` (`<https://github.com/golang/dep>`_)
 
 Checkout the source code


### PR DESCRIPTION
Building with Go 1.9 doesn't work anymore:

```
./generate.go:92:8: undefined: strings.Builder
./generate.go:105:9: undefined: strings.Builder
```