### PR TITLE
Fix for AlwaysData

### DIFF
--- a/tutorials.rst
+++ b/tutorials.rst
@@ -227,7 +227,7 @@ You can install Miniflux in few minutes on their platform.
     export LISTEN_ADDR=$ALWAYSDATA_HTTPD_IP:$ALWAYSDATA_HTTPD_PORT
     export DATABASE_URL="host=postgresql-xxxxx.alwaysdata.net dbname=xxxx user=xxxx password=xxx sslmode=disable"
 
-    ~/miniflux
+    env --unset PORT ~/miniflux
 
 7. Make the script executable: ``chmod +x start.sh``
 8. Run the db migrations and a create the first user:


### PR DESCRIPTION
Hello,

Unsetting AlwaysData's $PORT is required, otherwise Miniflux prefers $PORT over $LISTEN_ADDR and does not bind correctly.

By the way $PORT is not mentioned on configuration.rst, while it overloads $LISTEN_ADDR... Is this a bug (should not overload) or an undocumented feature?