### PR TITLE
Fix minimal PostgreSQL version

### DIFF
--- a/requirements.rst
+++ b/requirements.rst
@@ -21,7 +21,7 @@ Operating Systems
 Databases
 ---------
 
-- Postgresql >= 9.4
+- Postgresql >= 9.5
 
 Web Browsers
 ------------


### PR DESCRIPTION
When I tried to use Miniflux with a PostgreSQL 9.4 setup, I faced the following errors in logs: 

    Nov 18 17:34:35 XXXX journal: #011#011#011SET data = jsonb_set(data, '{language}', to_jsonb($1::text), true)#015
    Nov 18 17:34:35 XXXX journal: 2018-11-18 16:34:35 UTC [2452-31] miniflux@miniflux ERROR:  function to_jsonb(text) does not exist at character 57#015
    Nov 18 17:34:35 XXXX journal: #011#011#011SET data = jsonb_set(data, '{theme}', to_jsonb($1::text), true)#015
    Nov 18 17:34:35 XXXX journal: 2018-11-18 16:34:35 UTC [2452-34] miniflux@miniflux ERROR:  function to_jsonb(text) does not exist at character 65#015
    Nov 18 17:34:35 XXXX journal: #011#011#011SET data = jsonb_set(data, '{flash_message}', to_jsonb($1::text), true)#015

According to the official documentation ( [9.4](https://www.postgresql.org/docs/9.4/functions-json.html), [9.5](https://www.postgresql.org/docs/9.5/functions-json.html) ) function `to_jsonb()` was implemented in PostgreSQL 9.5.

This PR aims to reflect this requirement in the documentation.

Antoine