### PR TITLE
Add Readably to compatible apps

### DIFF
--- a/integration.rst
+++ b/integration.rst
@@ -18,6 +18,8 @@ Compatible Apps
 
 - `Reeder <http://reederapp.com/>`_ (iOS/Mac OS)
 - `Unread <https://www.goldenhillsoftware.com/unread/>`_ (iOS)
+- `Readably <https://play.google.com/store/apps/details?id=com.isaiasmatewos.readably>`_ (Android)
+
 
 .. note::
     - Saving an entry will add a new bookmark and save the article


### PR DESCRIPTION
Hi There!

I'm Isaias, I am the developer of Readably, an rss reader for Android. Readably has recently picked up Fever API support, so I want to ask if you could add it to the list of Fever API compatible apps in this file. Here is the link:

https://play.google.com/store/apps/details?id=com.isaiasmatewos.readably

Thanks, Isaias